### PR TITLE
Add a variable `go-translate-buffer-source-fold-p`.

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -72,6 +72,7 @@ M-x package-install go-translate RET
 其他的配置参数都是可选的，可在 `custom-group` - `go-translate` 中查看。比如:
 ```elisp
 (setq go-translate-buffer-follow-p t)       ; 翻译完成后，总是将光标切换到翻译结果窗口
+(setq go-translate-buffer-source-fold-p t)  ; 在结果页面，折叠源文本。可以通过回车或鼠标点击展开
 (setq go-translate-buffer-window-config ..) ; 更改翻译窗口的位置和样式
 
 ;; 设置输入风格。默认情况下，是通过 Minibuffer 方式补全用户输入

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you have any other translation plans, then put them into `go-translate-extra-
 Other customizations you can look into `custom-group` - `go-translate`, eg:
 ```elisp
 (setq go-translate-buffer-follow-p t)       ; focus the result window
+(setq go-translate-buffer-source-fold-p t)  ; fold the source text in the result window
 (setq go-translate-buffer-window-config ..) ; config the result window as your wish
 ```
 


### PR DESCRIPTION
It will control whether the source text should be folded for better display
on the translation result window.
