### PR TITLE
When translating documents, remove line breaks

### DIFF
--- a/go-translate.el
+++ b/go-translate.el
@@ -739,7 +739,7 @@ If BACKWARDP is t, then choose prev one."
          (if (pdf-view-active-region-p)
              (car (pdf-view-active-region-text))))
         ((use-region-p)
-         (string-trim (buffer-substring-no-properties (region-beginning) (region-end))))
+         (string-join (split-string(string-trim (buffer-substring-no-properties (region-beginning) (region-end)))) " "))
         (t (current-word t t))))
 
 (defun go-translate-default-prompt-inputs (&optional text direction)


### PR DESCRIPTION
当选择一大段文档进行翻译的时候,需要去除换行才能正确翻译.