### PR TITLE
feat: Add support for Azure OpenAI translation engine

### DIFF
--- a/README-zh.org
+++ b/README-zh.org
@@ -203,6 +203,7 @@ Taker 将从 =langs= 中选取要翻译的语言。默认会结合 =gt-lang-rule
 - =gt-bing-engine=, 微软翻译
 - =gt-google-engine/gt-google-rpc-engine=, Google 翻译
 - =gt-chatgpt-engine=, 使用 ChatGPT 进行翻译
+- =gt-azure-openai-engine=, 使用 Azure OpenAI 进行翻译
 - =gt-youdao-dict-engine/gt-youdao-suggest-engine=, 有道词典/有道近义词。主要用于中英互译
 - =gt-stardict-engine=, StarDict，支持外挂字典，可以用于离线翻译
 
@@ -460,6 +461,22 @@ ChatGPT 需要 apikey 才能正常使用:
 #+end_src
 
 另外，可以通过 =gt-do-speak= 尝试其语音播报。
+
+*** gt-azure-openai-engine
+
+Azure OpenAI 的设置与 ChatGPT 基本相同，有 3 点需要注意：
+
+1. 需要设置 gt-azure-openai-host ，格式为
+#+begin_src
+   https://[RESOURCE_NAME].openai.azure.com/openai/deployments/[DEPLOYMENT_NAME]
+#+end_src
+
+2. 如果在 authinfo 文件中保存 apikey ，authinfo 文件中的 'machine' 应为 gt-azure-openai-host 的主机名，格式如：
+#+begin_src
+machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
+#+end_src
+
+3. 注意与 ChatGPT 的模型名称区别，如 ChatGPT 的 'gpt-3.5-turbo' 在 Azure OpenAI 中是 'gpt-35-turbo'
 
 *** gt-buffer-render
 

--- a/README-zh.org
+++ b/README-zh.org
@@ -466,17 +466,17 @@ ChatGPT 需要 apikey 才能正常使用:
 
 Azure OpenAI 的设置与 ChatGPT 基本相同，有 3 点需要注意：
 
-1. 需要设置 gt-azure-openai-host ，格式为
-#+begin_src
+1. 需要设置 =gt-azure-openai-host= ，格式为
+   #+begin_src
    https://[RESOURCE_NAME].openai.azure.com/openai/deployments/[DEPLOYMENT_NAME]
-#+end_src
+   #+end_src
 
-2. 如果在 authinfo 文件中保存 apikey ，authinfo 文件中的 'machine' 应为 gt-azure-openai-host 的主机名，格式如：
-#+begin_src
-machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
-#+end_src
+2. 如果在 =.authinfo= 文件中保存 apikey ， =.authinfo= 文件中的 =machine= 应为 =gt-azure-openai-host= 的主机名，格式如：
+   #+begin_src
+   machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
+   #+end_src
 
-3. 注意与 ChatGPT 的模型名称区别，如 ChatGPT 的 'gpt-3.5-turbo' 在 Azure OpenAI 中是 'gpt-35-turbo'
+3. 注意与 ChatGPT 的模型名称区别，如 ChatGPT 的 =gpt-3.5-turbo= 在 Azure OpenAI 中是 =gpt-35-turbo=
 
 *** gt-buffer-render
 

--- a/README.org
+++ b/README.org
@@ -212,6 +212,7 @@ The built-in Engine implementations are:
 - =gt-bing-engine=, Bing Translate
 - =gt-google-engine/gt-google-rpc-engine=, Google Translate
 - =gt-chatgpt-engine=, translate with ChatGPT
+- =gt-azure-openai-engine=, translate with Azure OpenAI
 - =gt-youdao-dict-engine/gt-youdao-suggest-engine=, 有道翻译，有道近义词
 - =gt-stardict-engine=, StarDict，for offline translate
 
@@ -446,6 +447,22 @@ It support streaming output with some renders. Examples:
 #+end_src
 
 After all, try text to speech with command =gt-do-speak=.
+
+*** gt-azure-openai-engine
+
+The settings of Azure OpenAI are basically the same as ChatGPT. There are 3 points to note:
+
+1. You need to set 'gt-azure-openai-host' in the format of
+#+begin_src
+   https://[RESOURCE_NAME].openai.azure.com/openai/deployments/[DEPLOYMENT_NAME]
+#+end_src
+
+2. If apikey is saved in the authinfo file, 'machine' field in the authinfo file should be the host name of 'gt-azure-openai-host', in the format:
+#+begin_src
+machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
+#+end_src
+
+3. Pay attention to the difference in model names with ChatGPT. For example, 'gpt-3.5-turbo' in ChatGPT is 'gpt-35-turbo' in Azure OpenAI.
 
 *** gt-buffer-render
 

--- a/README.org
+++ b/README.org
@@ -452,17 +452,17 @@ After all, try text to speech with command =gt-do-speak=.
 
 The settings of Azure OpenAI are basically the same as ChatGPT. There are 3 points to note:
 
-1. You need to set 'gt-azure-openai-host' in the format of
-#+begin_src
+1. You need to set =gt-azure-openai-host= in the format of
+   #+begin_src
    https://[RESOURCE_NAME].openai.azure.com/openai/deployments/[DEPLOYMENT_NAME]
-#+end_src
+   #+end_src
 
-2. If apikey is saved in the authinfo file, 'machine' field in the authinfo file should be the host name of 'gt-azure-openai-host', in the format:
-#+begin_src
-machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
-#+end_src
+2. If apikey is saved in the =.authinfo= file, =machine= field in the =.authinfo= file should be the host name of =gt-azure-openai-host=, in the format:
+   #+begin_src
+   machine [RESOURCE_NAME].openai.azure.com login apikey password [YOUR_KEY]
+   #+end_src
 
-3. Pay attention to the difference in model names with ChatGPT. For example, 'gpt-3.5-turbo' in ChatGPT is 'gpt-35-turbo' in Azure OpenAI.
+3. Pay attention to the difference in model names with ChatGPT. For example, =gpt-3.5-turbo= in ChatGPT is =gpt-35-turbo= in Azure OpenAI.
 
 *** gt-buffer-render
 

--- a/go-translate.el
+++ b/go-translate.el
@@ -69,6 +69,7 @@
 (require 'gt-engine-stardict)
 (require 'gt-engine-youdao)
 (require 'gt-engine-chatgpt)
+(require 'gt-engine-azure-openai)
 (require 'gt-engine-echo)
 (require 'gt-text-utility)
 
@@ -134,6 +135,8 @@ of `gt-default-translator' at any time in `gt-do-setup'."
       (Google               . ,(gt-google-engine))
       (ChatGPT              . ,(gt-chatgpt-engine))
       (ChatGPT-Stream       . ,(gt-chatgpt-engine :stream t))
+      (Azure-OpenAI              . ,(gt-azure-openai-engine))
+      (Azure-OpenAI-Stream       . ,(gt-azure-openai-engine :stream t))
       (Youdao-Dict          . ,(gt-youdao-dict-engine))
       (Youdao-Suggest       . ,(gt-youdao-suggest-engine))
       (StarDict             . ,(gt-stardict-engine))

--- a/gt-engine-azure-openai.el
+++ b/gt-engine-azure-openai.el
@@ -1,0 +1,158 @@
+;;; gt-engine-azure-openai.el --- Engine for Azure-OpenAI -*- lexical-binding: t -*-
+
+;; Copyright (C) 2024 lorniu <lorniu@gmail.com>
+;; Author: lorniu <lorniu@gmail.com>
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;; This file is NOT part of GNU Emacs.
+
+;;; Commentary:
+
+;; https://platform.openai.com/docs/api-reference
+
+;;; Code:
+
+(require 'gt-extension)
+
+(defgroup go-translate-azure-openai nil
+  "Configs for Azure-OpenAI engine."
+  :group 'go-translate)
+
+
+;;; Components
+
+(defclass gt-azure-openai-engine (gt-engine)
+  ((tag         :initform 'Azure-OpenAI)
+   (host        :initarg :host :initform nil)
+   (model       :initarg :model :initform nil)
+   (temperature :initarg :temperature :initform nil)
+   (key         :initarg :key :initform 'apikey
+                :documentation "The apikey of Azure-OpenAI.
+Can also put into .authinfo file as:
+  machine api.openai.com login apikey password ***")))
+
+
+;;; Translate
+
+(defcustom gt-azure-openai-host nil
+  "API host of Azure-OpenAI."
+  :type 'string
+  :group 'go-translate-azure-openai)
+
+(defcustom gt-azure-openai-key nil
+  "Auth Key of Azure-OpenAI. Recommend to save in .authinfo file instead."
+  :type 'string
+  :group 'go-translate-azure-openai)
+
+(defcustom gt-azure-openai-model "gpt-3.5-turbo"
+  "Model to be used in chat."
+  :type 'string
+  :group 'go-translate-azure-openai)
+
+(defcustom gt-azure-openai-temperature 0.8
+  "Temperature of Azure-OpenAI."
+  :type 'number
+  :group 'go-translate-azure-openai)
+
+(defcustom gt-azure-openai-system-prompt "You are a translation assistant"
+  "System prompt send to server when translation."
+  :type 'string
+  :group 'go-translate-azure-openai)
+
+(defcustom gt-azure-openai-user-prompt-template "Translate the text to %s, text is: \n%s"
+  "Template for user prompt when translation.
+When it is string, %s is placeholders of lang and text.
+When it is function, arguments passed to it should be text and lang."
+  :type '(choice string function)
+  :group 'go-translate-azure-openai)
+
+(declare-function pulse-momentary-highlight-region "pulse")
+
+(defvar gt-azure-openai-streaming-finished-hook #'pulse-momentary-highlight-region
+  "The logic runs after all streams finished.
+With two arguments BEG and END, which are the marker bounds of the result.")
+
+(cl-defmethod gt-ensure-key ((engine gt-azure-openai-engine))
+  (with-slots (host key) engine
+    (unless (stringp key)
+      (if-let (apikey (or (gt-lookup-password
+                           :user (if key (format "%s" key) "apikey")
+                           :host (url-host (url-generic-parse-url (or host gt-azure-openai-host))))
+                          gt-azure-openai-key))
+          (setf key apikey)
+        (user-error "You should provide a apikey for gt-azure-openai-engine")))))
+
+(cl-defmethod gt-translate ((engine gt-azure-openai-engine) task next)
+  (gt-ensure-key engine)
+  (with-slots (text src tgt res translator markers) task
+    (with-slots (host key model temperature stream) engine
+      (when (and stream (cdr (oref translator text)))
+        (user-error "Multiple parts not support streaming"))
+      (gt-request :url (concat (or host gt-azure-openai-host) "/chat/completions?api-version=2023-05-15")
+                  :headers `(("Content-Type" . "application/json")
+                             ("api-key" . ,(encode-coding-string key 'utf-8)))
+                  :data (encode-coding-string
+                         (json-encode
+                          `((model . ,(or model gt-azure-openai-model))
+                            (temperature . ,(or temperature gt-azure-openai-temperature))
+                            (stream . ,stream)
+                            (messages . [((role . system)
+                                          (content . ,gt-azure-openai-system-prompt))
+                                         ((role . user)
+                                          (content . ,(if (functionp gt-azure-openai-user-prompt-template)
+                                                          (funcall gt-azure-openai-user-prompt-template text tgt)
+                                                        (format gt-azure-openai-user-prompt-template (alist-get tgt gt-lang-codes) text))))])))
+                         'utf-8)
+                  :filter (when stream
+                            (lambda ()
+                              (unless gt-tracking-marker
+                                (setq gt-tracking-marker (make-marker))
+                                (set-marker gt-tracking-marker (point-min)))
+                              (goto-char gt-tracking-marker)
+                              (condition-case err
+                                  (while (re-search-forward "^data: +\\({.+}\\)" nil t)
+                                    (let* ((json (json-read-from-string (decode-coding-string (match-string 1) 'utf-8)))
+                                           (choice (aref (alist-get 'choices json) 0))
+                                           (content (alist-get 'content (alist-get 'delta choice)))
+                                           (finish (alist-get 'finish_reason choice)))
+                                      (if finish
+                                          (progn (message "")
+                                                 (when gt-azure-openai-streaming-finished-hook
+                                                   (with-current-buffer (marker-buffer (car markers))
+                                                     (funcall gt-azure-openai-streaming-finished-hook (car markers) (cdr markers)))))
+                                        (setf res (concat res content))
+                                        (set-marker gt-tracking-marker (point))
+                                        (unless (string-blank-p (concat res))
+                                          (funcall next task)))))
+                                (error (unless (string-prefix-p "json" (format "%s" (car err)))
+                                         (signal (car err) (cdr err)))))))
+                  :done (unless stream
+                          (lambda (raw)
+                            (with-slots (res) task
+                              (let* ((json (json-read-from-string raw))
+                                     (str (alist-get 'content (alist-get 'message (let-alist json (aref .choices 0))))))
+                                (setf res str))
+                              (funcall next task))))
+                  :fail (lambda (err) (gt-fail task err))))))
+
+(cl-defmethod gt-stream-p ((engine gt-azure-openai-engine))
+  (oref engine stream))
+
+
+(provide 'gt-engine-azure-openai)
+
+;;; gt-engine-azure-openai.el ends here


### PR DESCRIPTION
按照 chatgpt 的样子抄了一份用在 azure openai 上，测试了下可以正常运行。
不知道有没有更简单的方法从 chatgpt 上扩展成 azure openai ，毕竟功能基本相同。
对代码不是很熟悉，只有用这种抄的方法弄了一个，就比较冒失的发了上来，还请大佬决断。
另外，api-version 用的是 2023-05-15 ，原因是用新的版本 stream 会出错。