### PR TITLE
add gpt-chatgpt-endpoint

### DIFF
--- a/gt-engine-chatgpt.el
+++ b/gt-engine-chatgpt.el
@@ -52,6 +52,10 @@ Can also put into .authinfo file as:
   "API host of ChatGPT."
   :type 'string
   :group 'go-translate-chatgpt)
+(defcustom gt-chatgpt-endpoint "/v1/chat/completions"
+  "API endpoint of ChatGPT."
+  :type 'string
+  :group 'go-translate-chatgpt)
 
 (defcustom gt-chatgpt-key nil
   "Auth Key of ChatGPT. Recommend to save in .authinfo file instead."
@@ -102,7 +106,7 @@ With two arguments BEG and END, which are the marker bounds of the result.")
     (with-slots (host key model temperature stream) engine
       (when (and stream (cdr (oref translator text)))
         (user-error "Multiple parts not support streaming"))
-      (gt-request :url (concat (or host gt-chatgpt-host) "/v1/chat/completions")
+      (gt-request :url (concat (or host gt-chatgpt-host) gt-chatgpt-endpoint)
                   :headers `(("Content-Type" . "application/json")
                              ("Authorization" . ,(concat "Bearer " (encode-coding-string key 'utf-8))))
                   :data (encode-coding-string


### PR DESCRIPTION
方便支持 兼容gpt的实现，比如 字节的方舟 https://www.volcengine.com/docs/82379/1298454
```
  (setq gt-chatgpt-host "https://ark.cn-beijing.volces.com")
  (setq gt-chatgpt-endpoint "/api/v3/chat/completions")
  (setq gt-chatgpt-model "model")
```